### PR TITLE
Added option to customize the configuration separator 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Where following parameters are used:
 * `-id=./pict_dir_1` or `--imageDirectories=./pict_dir_1` - a path to directory with images. You can set several directories.
 * `-ct=0.05` or `--compareThreshold=0.05` - an image compare threshold. Standard deviation threshold for duplicates. By default it is equal to 0.05.
 * `-of=./dupl_list.txt` or `--outFile=./dupl_list.txt` - a file name to save list with found duplicated and damaged images. A path to image with poor quality is printed at the beginning of line.
+* `-dl='\t'` or `--delimiter='\t'`  - Create separators for fields when outputting files. By default,`\t`is used as a delimiter.
 
 Also you can use parameters:
 * `--help` or `-h` - to print this help message.

--- a/src/AntiDuplX/AdxOptions.h
+++ b/src/AntiDuplX/AdxOptions.h
@@ -47,6 +47,7 @@ namespace Adx
         Matcher::HashType compareSize;
         size_t threadNumber;
         String outFile;
+        String delimiter;
         bool deleteDupls;
         bool deleteBads;
 
@@ -72,6 +73,7 @@ namespace Adx
             compareSize = ToHashType(GetArg2("-cs", "--compareSize", "32x32", false));
             threadNumber = std::min<size_t>(std::max<size_t>(Cpl::ToVal<size_t>(GetArg2("-tn", "--threadNumber", "-1", false)), 1), std::thread::hardware_concurrency());
             outFile = GetArg2("-of", "--outFile", "out.txt", false);
+            delimiter = GetArg2("-dl", "--delimiter", "\t");
             deleteDupls = Cpl::ToVal<bool>(GetArg2("-dd", "--deleteDupls", "0"));
             deleteBads = Cpl::ToVal<bool>(GetArg2("-db", "--deleteBads", "0"));
         }
@@ -95,6 +97,8 @@ namespace Adx
             std::cout << "                                                       By default it is equal to 0.05." << std::endl << std::endl;
             std::cout << "  -of=./dupl_list.txt or --outFile=./dupl_list.txt   - a file name to save list with found duplicated and damaged images." << std::endl;
             std::cout << "                                                       A path to image with poor quality is printed at the beginning of line." << std::endl << std::endl;
+            std::cout << "  -dl='\t' or --delimiter='\t'                       - Create separators for fields when outputting files." << std::endl;
+            std::cout << "                                                       By default, \t is used as the delimiter, and the presence of \t in the path may result in serial output." << std::endl << std::endl;
             std::cout << "Also you can use parameters: " << std::endl << std::endl;
             std::cout << "  --help or -h                       - to print this help message." << std::endl << std::endl;
             std::cout << "  --version or -v                    - to print AntiDuplX version." << std::endl << std::endl;

--- a/src/AntiDuplX/AdxOptions.h
+++ b/src/AntiDuplX/AdxOptions.h
@@ -65,7 +65,7 @@ namespace Adx
                 exit(0);
             }
             imageDirectories = GetArgs(Strings({ "-id", "--imageDirectories" }), Strings({"."}));
-            imageExtensions = GetArgs(Strings({ "-ie", "--imageExtensions" }), Strings( { ".jpg", ".png"}));
+            imageExtensions = GetArgs(Strings({ "-ie", "--imageExtensions" }), Strings( { ".jpg", ".png", ".jpeg"}));
             subDirectories = Cpl::ToVal<bool>(GetArg2("-sd", "--subDirectory", "1"));
             logLevel = (Cpl::Log::Level)Cpl::ToVal<Int>(GetArg2("-ll", "--logLevel", "3", false));
             performanceReport = Cpl::ToVal<bool>(GetArg2("-pr", "--performanceReport", "0"));
@@ -98,7 +98,7 @@ namespace Adx
             std::cout << "  -of=./dupl_list.txt or --outFile=./dupl_list.txt   - a file name to save list with found duplicated and damaged images." << std::endl;
             std::cout << "                                                       A path to image with poor quality is printed at the beginning of line." << std::endl << std::endl;
             std::cout << "  -dl='\t' or --delimiter='\t'                       - Create separators for fields when outputting files." << std::endl;
-            std::cout << "                                                       By default, \t is used as the delimiter, and the presence of \t in the path may result in serial output." << std::endl << std::endl;
+            std::cout << "                                                       By default,'\t'is used as a delimiter." << std::endl << std::endl;
             std::cout << "Also you can use parameters: " << std::endl << std::endl;
             std::cout << "  --help or -h                       - to print this help message." << std::endl << std::endl;
             std::cout << "  --version or -v                    - to print AntiDuplX version." << std::endl << std::endl;

--- a/src/AntiDuplX/AdxOptions.h
+++ b/src/AntiDuplX/AdxOptions.h
@@ -36,111 +36,111 @@
 
 namespace Adx
 {
-    struct Options : public Cpl::ArgsParser
-    {
-        Strings imageDirectories;
-        Strings imageExtensions;
-        bool subDirectories;
-        Cpl::Log::Level logLevel;
-        bool performanceReport;
-        double compareThreshold;
-        Matcher::HashType compareSize;
-        size_t threadNumber;
-        String outFile;
-        String delimiter;
-        bool deleteDupls;
-        bool deleteBads;
+	struct Options : public Cpl::ArgsParser
+	{
+		Strings imageDirectories;
+		Strings imageExtensions;
+		bool subDirectories;
+		Cpl::Log::Level logLevel;
+		bool performanceReport;
+		double compareThreshold;
+		Matcher::HashType compareSize;
+		size_t threadNumber;
+		String outFile;
+		String delimiter;
+		bool deleteDupls;
+		bool deleteBads;
 
-        Options(int argc, char* argv[])
-            : ArgsParser(argc, argv, true)
-        {
-            if (HasArg("-h", "--help"))
-            {
-                PrintHelp();
-                exit(0);
-            }
-            if (HasArg("-v", "--version"))
-            {
-                PrintVersion();
-                exit(0);
-            }
-            imageDirectories = GetArgs(Strings({ "-id", "--imageDirectories" }), Strings({"."}));
-            imageExtensions = GetArgs(Strings({ "-ie", "--imageExtensions" }), Strings( { ".jpg", ".png", ".jpeg"}));
-            subDirectories = Cpl::ToVal<bool>(GetArg2("-sd", "--subDirectory", "1"));
-            logLevel = (Cpl::Log::Level)Cpl::ToVal<Int>(GetArg2("-ll", "--logLevel", "3", false));
-            performanceReport = Cpl::ToVal<bool>(GetArg2("-pr", "--performanceReport", "0"));
-            compareThreshold = Cpl::ToVal<double>(GetArg2("-ct", "--compareThreshold", "0.05", false));
-            compareSize = ToHashType(GetArg2("-cs", "--compareSize", "32x32", false));
-            threadNumber = std::min<size_t>(std::max<size_t>(Cpl::ToVal<size_t>(GetArg2("-tn", "--threadNumber", "-1", false)), 1), std::thread::hardware_concurrency());
-            outFile = GetArg2("-of", "--outFile", "out.txt", false);
-            delimiter = GetArg2("-dl", "--delimiter", "\t");
-            deleteDupls = Cpl::ToVal<bool>(GetArg2("-dd", "--deleteDupls", "0"));
-            deleteBads = Cpl::ToVal<bool>(GetArg2("-db", "--deleteBads", "0"));
-        }
+		Options(int argc, char* argv[])
+			: ArgsParser(argc, argv, true)
+		{
+			if (HasArg("-h", "--help"))
+			{
+				PrintHelp();
+				exit(0);
+			}
+			if (HasArg("-v", "--version"))
+			{
+				PrintVersion();
+				exit(0);
+			}
+			imageDirectories = GetArgs(Strings({ "-id", "--imageDirectories" }), Strings({ "." }));
+			imageExtensions = GetArgs(Strings({ "-ie", "--imageExtensions" }), Strings({ ".jpg", ".png", ".jpeg" }));
+			subDirectories = Cpl::ToVal<bool>(GetArg2("-sd", "--subDirectory", "1"));
+			logLevel = (Cpl::Log::Level)Cpl::ToVal<Int>(GetArg2("-ll", "--logLevel", "3", false));
+			performanceReport = Cpl::ToVal<bool>(GetArg2("-pr", "--performanceReport", "0"));
+			compareThreshold = Cpl::ToVal<double>(GetArg2("-ct", "--compareThreshold", "0.05", false));
+			compareSize = ToHashType(GetArg2("-cs", "--compareSize", "32x32", false));
+			threadNumber = std::min<size_t>(std::max<size_t>(Cpl::ToVal<size_t>(GetArg2("-tn", "--threadNumber", "-1", false)), 1), std::thread::hardware_concurrency());
+			outFile = GetArg2("-of", "--outFile", "out.txt", false);
+			delimiter = GetArg2("-dl", "--delimiter", "\t");
+			deleteDupls = Cpl::ToVal<bool>(GetArg2("-dd", "--deleteDupls", "0"));
+			deleteBads = Cpl::ToVal<bool>(GetArg2("-db", "--deleteBads", "0"));
+		}
 
-        ~Options()
-        {
-        }
+		~Options()
+		{
+		}
 
 
-    private:
-        void PrintHelp()
-        {
-            std::cout << "AntiDuplX is a command line tool to search of simular images." << std::endl << std::endl;
-            std::cout << "Using example:" << std::endl << std::endl;
-            std::cout << "  ./AntiDuplX -id=./pict_dir_1 -id=./pict_dir_2 -ct=0.05 -of=./dupl_list.txt" << std::endl << std::endl;
-            std::cout << "Where following parameters are used:" << std::endl << std::endl;
-            std::cout << "  -id=./pict_dir_1 or --imageDirectories=./pict_dir_1 - a path to directory with images. " << std::endl;
-            std::cout << "                                                       You can set several directories." << std::endl << std::endl;
-            std::cout << "  -ct=0.05 or --compareThreshold=0.05                - an image compare threshold." << std::endl;
-            std::cout << "                                                       Standard deviation threshold for duplicates." << std::endl;
-            std::cout << "                                                       By default it is equal to 0.05." << std::endl << std::endl;
-            std::cout << "  -of=./dupl_list.txt or --outFile=./dupl_list.txt   - a file name to save list with found duplicated and damaged images." << std::endl;
-            std::cout << "                                                       A path to image with poor quality is printed at the beginning of line." << std::endl << std::endl;
-            std::cout << "  -dl='\t' or --delimiter='\t'                       - Create separators for fields when outputting files." << std::endl;
-            std::cout << "                                                       By default,'\t'is used as a delimiter." << std::endl << std::endl;
-            std::cout << "Also you can use parameters: " << std::endl << std::endl;
-            std::cout << "  --help or -h                       - to print this help message." << std::endl << std::endl;
-            std::cout << "  --version or -v                    - to print AntiDuplX version." << std::endl << std::endl;
-            std::cout << "  --imageExtensions=.jpg or -ie=.jpg - an image file extensions to search." << std::endl;
-            std::cout << "                                       You can set several extensions." << std::endl;
-            std::cout << "                                       By default this parameter is equal to (.jpg, .png)." << std::endl << std::endl;
-            std::cout << "  --subDirectories=1 or -sd=1        - to search images in sub-directories." << std::endl;
-            std::cout << "                                       By default this parameter is turned on." << std::endl << std::endl;
-            std::cout << "  --logLevel=3 or -ll=3              - a log level. It can be: 0 - None, 1 - Error, 2 - Warning, 3 - Info, 4 - Verbose, 5 - Debug." << std::endl;
-            std::cout << "                                       By default this parameter is equal to 3 (Info)." << std::endl << std::endl;
-            std::cout << "  --performanceReport=1 or -pr=1     - a flag to print performance report." << std::endl;
-            std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
-            std::cout << "  --compareSize=32x32 or -cs=32x32   - an image compare size. It can be 16x16, 32x32 or 64x64." << std::endl;
-            std::cout << "                                       By default this parameter is equal to 32x32." << std::endl << std::endl;
-            std::cout << "  --threadNumber=4 or -tn=4          - a number of work threads to load and compare images." << std::endl;
-            std::cout << "                                       By default this parameter is equal to -1 (use of all available threads)." << std::endl << std::endl;
-            std::cout << "  --deleteDupls=1 or -dd=1           - a flag to auto delete found image duplicates." << std::endl;
-            std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
-            std::cout << "  --deleteBads=1 or -db=1            - a flag to auto delete found bad (damaged) images." << std::endl;
-            std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
-        } 
+	private:
+		void PrintHelp()
+		{
+			std::cout << "AntiDuplX is a command line tool to search of simular images." << std::endl << std::endl;
+			std::cout << "Using example:" << std::endl << std::endl;
+			std::cout << "  ./AntiDuplX -id=./pict_dir_1 -id=./pict_dir_2 -ct=0.05 -of=./dupl_list.txt" << std::endl << std::endl;
+			std::cout << "Where following parameters are used:" << std::endl << std::endl;
+			std::cout << "  -id=./pict_dir_1 or --imageDirectories=./pict_dir_1 - a path to directory with images. " << std::endl;
+			std::cout << "                                                       You can set several directories." << std::endl << std::endl;
+			std::cout << "  -ct=0.05 or --compareThreshold=0.05                - an image compare threshold." << std::endl;
+			std::cout << "                                                       Standard deviation threshold for duplicates." << std::endl;
+			std::cout << "                                                       By default it is equal to 0.05." << std::endl << std::endl;
+			std::cout << "  -of=./dupl_list.txt or --outFile=./dupl_list.txt   - a file name to save list with found duplicated and damaged images." << std::endl;
+			std::cout << "                                                       A path to image with poor quality is printed at the beginning of line." << std::endl << std::endl;
+			std::cout << "  -dl='\\t' or --delimiter='\\t'                       - Create separators for fields when outputting files." << std::endl;
+			std::cout << "                                                       By default,'\t'is used as a delimiter." << std::endl << std::endl;
+			std::cout << "Also you can use parameters: " << std::endl << std::endl;
+			std::cout << "  --help or -h                       - to print this help message." << std::endl << std::endl;
+			std::cout << "  --version or -v                    - to print AntiDuplX version." << std::endl << std::endl;
+			std::cout << "  --imageExtensions=.jpg or -ie=.jpg - an image file extensions to search." << std::endl;
+			std::cout << "                                       You can set several extensions." << std::endl;
+			std::cout << "                                       By default this parameter is equal to (.jpg, .png)." << std::endl << std::endl;
+			std::cout << "  --subDirectories=1 or -sd=1        - to search images in sub-directories." << std::endl;
+			std::cout << "                                       By default this parameter is turned on." << std::endl << std::endl;
+			std::cout << "  --logLevel=3 or -ll=3              - a log level. It can be: 0 - None, 1 - Error, 2 - Warning, 3 - Info, 4 - Verbose, 5 - Debug." << std::endl;
+			std::cout << "                                       By default this parameter is equal to 3 (Info)." << std::endl << std::endl;
+			std::cout << "  --performanceReport=1 or -pr=1     - a flag to print performance report." << std::endl;
+			std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
+			std::cout << "  --compareSize=32x32 or -cs=32x32   - an image compare size. It can be 16x16, 32x32 or 64x64." << std::endl;
+			std::cout << "                                       By default this parameter is equal to 32x32." << std::endl << std::endl;
+			std::cout << "  --threadNumber=4 or -tn=4          - a number of work threads to load and compare images." << std::endl;
+			std::cout << "                                       By default this parameter is equal to -1 (use of all available threads)." << std::endl << std::endl;
+			std::cout << "  --deleteDupls=1 or -dd=1           - a flag to auto delete found image duplicates." << std::endl;
+			std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
+			std::cout << "  --deleteBads=1 or -db=1            - a flag to auto delete found bad (damaged) images." << std::endl;
+			std::cout << "                                       By default this parameter is turned off." << std::endl << std::endl;
+		}
 
-        void PrintVersion()
-        {
-            std::cout << "AntiDuplX-" << ADX_VERSION << std::endl;
-        }
+		void PrintVersion()
+		{
+			std::cout << "AntiDuplX-" << ADX_VERSION << std::endl;
+		}
 
-        Matcher::HashType ToHashType(const String& str)
-        {
-            if (str == "16x16")
-                return Matcher::Hash16x16;
-            else if (str == "32x32")
-                return Matcher::Hash32x32;
-            else if (str == "64x64")
-                return Matcher::Hash64x64;
-            else
-            {
-                CPL_LOG_SS(Error, "Invalid parameter --compareSize=" << str << "! . It can be 16x16, 32x32 or 64x64.");
-                exit(1);
-                return Matcher::Hash16x16;
-            }
-        }
-    };
+		Matcher::HashType ToHashType(const String& str)
+		{
+			if (str == "16x16")
+				return Matcher::Hash16x16;
+			else if (str == "32x32")
+				return Matcher::Hash32x32;
+			else if (str == "64x64")
+				return Matcher::Hash64x64;
+			else
+			{
+				CPL_LOG_SS(Error, "Invalid parameter --compareSize=" << str << "! . It can be 16x16, 32x32 or 64x64.");
+				exit(1);
+				return Matcher::Hash16x16;
+			}
+		}
+	};
 }
 

--- a/src/AntiDuplX/AdxResultHandler.cpp
+++ b/src/AntiDuplX/AdxResultHandler.cpp
@@ -43,6 +43,8 @@ namespace Adx
 
     bool ResultHandler::SaveOutFile()
     {
+        std::string delimiter = _options.delimiter;
+
         if (_options.outFile.empty())
             return true;
         fs::path path(_options.outFile);
@@ -58,7 +60,6 @@ namespace Adx
                     return false;
                 }
             }
-
         }
         std::ofstream ofs(_options.outFile.c_str());
         if (!ofs.is_open())
@@ -72,8 +73,8 @@ namespace Adx
             const ImageInfo& info = *_imageInfos[i];
             if (info.error)
             {
-                ofs << info.path << "\t";
-                ofs << info.width << "x" << info.height << "\t";
+                ofs << info.path << delimiter;
+                ofs << info.width << "x" << info.height << delimiter;
                 ofs << info.size / 1024 << "kb";
                 ofs << std::endl;
                 if (_options.deleteBads)
@@ -87,12 +88,12 @@ namespace Adx
             }
             if (info.duplicate)
             {
-                ofs << info.path << "\t";
-                ofs << info.width << "x" << info.height << "\t";
-                ofs << info.size / 1024 << "kb\t";
-                ofs << info.difference << "\t";
-                ofs << info.duplicate->path << "\t";
-                ofs << info.duplicate->width << "x" << info.duplicate->height << "\t";
+                ofs << info.path << delimiter;
+                ofs << info.width << "x" << info.height << delimiter;
+                ofs << info.size / 1024 << "kb" << delimiter;
+                ofs << info.difference << delimiter;
+                ofs << info.duplicate->path << delimiter;
+                ofs << info.duplicate->width << "x" << info.duplicate->height << delimiter;
                 ofs << info.duplicate->size / 1024 << "kb";
                 ofs << std::endl;
                 if (_options.deleteDupls)
@@ -110,4 +111,3 @@ namespace Adx
         return true;
     }
 }
-


### PR DESCRIPTION
1. Add `.jpeg` type to the default image type specification options
Added parameter `String delimiter` to `AdxOptions.h`; 
          - Create separators for fields when outputting files. By default, '\t' is used as a delimiter.

2. Added `std::string delimiter = _options.delimiter;` to `AdxResultHandler.cpp`, and changed the delimiter of `info.error` and `info.duplicate` file output paths from the default `\t` to delimiter.

3. Added corresponding description to the Readme file  
* `-dl='\t'` or `--delimiter='\t'` - Create separators for fields when outputting files. By default, `\t` is used as a delimiter.


---
I used Python's pandas package to read txt files before, but there were always some columns not in the correct position. I found that the reason was the delimiter. By rewriting the delimiter, it will be correctly recognized and the output file can be correctly parsed by other programs.
  i build for windows and run powershell with follow 

Да таго, як я выкарыстаў пакет Python для чытання txt, некаторыя слупкі былі не ў правільным становішчы, таму, перапісаўшы падзельнік, ён будзе правільна распазнаны, і выніковы файл можа быць правільна разабраны іншымі праграмамі.

```shell
.\AntiDuplX.exe -id="./testpic"  -ct=0.00 -of="./dupl_list3.txt" -dl='@@@'
```
```
./testpic\1720780531362 - Copy (2).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (3).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (3).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (4).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (4).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (5).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (5).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (6).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (6).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (7).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (7).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy (8).png@@@268x240@@@47kb
./testpic\1720780531362 - Copy (8).png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362 - Copy.png@@@268x240@@@47kb
./testpic\1720780531362 - Copy.png@@@268x240@@@47kb@@@0@@@./testpic\1720780531362.png@@@268x240@@@47kb

```


---

1. Дадайце тып `.jpeg` да параметраў спецыфікацыі тыпу выявы па змаўчанні
Дададзены параметр `Раздзяляльнік радкоў` у `AdxOptions.h`;
 - Стварэнне падзельнікаў для палёў пры вывадзе файлаў. Па змаўчанні ў якасці раздзяляльніка выкарыстоўваецца "\t".

2. Дададзены `std::string delimiter = _options.delimiter;` у `AdxResultHandler.cpp` і зменены падзельнік шляхоў вываду файлаў `info.error` і `info.duplicate` са стандартнага `\t` на падзельнік .

3. Дададзена адпаведнае апісанне ў файл Readme
* `-dl='\t'` або `--delimiter='\t'` - Стварэнне падзельнікаў для палёў пры вывадзе файлаў. Па змаўчанні ў якасці раздзяляльніка выкарыстоўваецца "\t".
